### PR TITLE
Support MultiPart uploads as well

### DIFF
--- a/drf_base64/fields.py
+++ b/drf_base64/fields.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.forms import ImageField
+from django.core.files.uploadedfile import UploadedFile
 from drf_extra_fields.fields import Base64FieldMixin, Base64FileField, Base64ImageField
 from drf_yasg import openapi
 from rest_framework.exceptions import ValidationError
@@ -16,6 +17,7 @@ class NamedBase64FieldMixin(Base64FieldMixin):
     INVALID_OBJECT = 'Must be an object containing keys "file_name" and "encoded_str"'
     INVALID_DATA = '"URL starting with http" or "Object with file_name and encoded_str must be passed"'
     INVALID_FILE_NAME = 'The file name is incorrect. It should have the form "<name>.<extension>"'
+    INVALID_FILE_UPLOAD = 'The file uploaded directly is invalid, must have a name and size'
     ALLOWED_TYPES = [
         'jpeg',
         'jpg',
@@ -51,6 +53,22 @@ class NamedBase64FieldMixin(Base64FieldMixin):
 
             encoded_str = obj['encoded_str']
             return super().to_internal_value(encoded_str)
+        elif isinstance(obj, UploadedFile):
+            try:
+                self.name = obj.name
+                self.size = obj.size
+            except AttributeError:
+                raise ValidationError(self.INVALID_FILE_UPLOAD)
+
+            try:
+                _, self.ext = self.name.rsplit('.', 1)
+            except ValueError:
+                raise ValidationError(self.INVALID_FILE_NAME)
+
+            if self.ext not in self.ALLOWED_TYPES and not self.ALLOW_ALL_EXTENSIONS:
+                raise ValidationError(self.INVALID_TYPE_MESSAGE)
+
+            return obj
         else:
             raise ValidationError(self.INVALID_DATA)
 


### PR DESCRIPTION
Hi there. First off wanted to say that this is a nice project, simple and to the point. I also really appreciate how it supports drf-yasg definitions up front. Makes it really nice to work with for openapi clients!

So we ran into a small issue where we wanted to support Multipart file uploads (like from the built-in browsable api) https://www.django-rest-framework.org/topics/browsable-api/ in addition to the base64 client case.

With this small patch, now it supports it. Yay! (inspiration taken from https://github.com/encode/django-rest-framework/blob/master/rest_framework/fields.py#L1528 for including it directly)

Hope this is useful, I couldn't get the test-suite to run for this project, but happy to change anything and open to any feedback.

Thanks again!